### PR TITLE
feat: add TOTP auto-generation for MFA profiles

### DIFF
--- a/cmd/console.go
+++ b/cmd/console.go
@@ -13,6 +13,7 @@ import (
 
 	"awsm/internal/aws"
 	"awsm/internal/browser"
+	"awsm/internal/mfa"
 	"awsm/internal/tui"
 
 	"github.com/spf13/cobra"
@@ -58,11 +59,15 @@ Make sure to set a session first with 'awsm profile set <profile-name>' or use -
 			}
 		}
 
-		// Check if profile needs MFA and prompt before any SDK call
-		// Skip if we have valid cached credentials
+		// Check if profile needs MFA — auto-generate from stored TOTP secret, else prompt.
+		// Skip entirely if we have valid cached credentials.
 		var mfaToken string
 		if needsMFA, mfaSerial, mfaErr := aws.ProfileNeedsMFA(currentProfile); mfaErr == nil && needsMFA && !aws.HasValidCachedCredentials(currentProfile) {
-			mfaToken, _ = tui.PromptInput(fmt.Sprintf("MFA token for %s", tui.FormatBold(mfaSerial)))
+			if code, totpErr := mfa.GenerateTOTP(currentProfile); totpErr == nil {
+				mfaToken = code
+			} else {
+				mfaToken, _ = tui.PromptInput(fmt.Sprintf("MFA token for %s", tui.FormatBold(mfaSerial)))
+			}
 		}
 
 		// Retrieve credentials using internal helper to ensure freshness for chained profiles

--- a/cmd/internal_helpers.go
+++ b/cmd/internal_helpers.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"awsm/internal/aws"
+	"awsm/internal/mfa"
 	"awsm/internal/tui"
 )
 
@@ -16,14 +17,18 @@ import (
 //
 // Returns the credentials, whether they are static, and any error.
 func ensureCredentialsWithLogin(ctx context.Context, profileName string) (*aws.TempCredentials, bool, error) {
-	// Handle MFA prompt before any spinner so stdin remains usable.
+	// Handle MFA before any spinner so stdin remains usable.
 	var mfaToken string
 	if needsMFA, mfaSerial, mfaErr := aws.ProfileNeedsMFA(profileName); mfaErr == nil && needsMFA && !aws.HasValidCachedCredentials(profileName) {
-		token, err := tui.PromptInput(fmt.Sprintf("MFA token for %s", tui.FormatBold(mfaSerial)))
-		if err != nil {
-			return nil, false, fmt.Errorf("failed to read MFA token: %w", err)
+		if code, totpErr := mfa.GenerateTOTP(profileName); totpErr == nil {
+			mfaToken = code
+		} else {
+			token, err := tui.PromptInput(fmt.Sprintf("MFA token for %s", tui.FormatBold(mfaSerial)))
+			if err != nil {
+				return nil, false, fmt.Errorf("failed to read MFA token: %w", err)
+			}
+			mfaToken = token
 		}
-		mfaToken = token
 	}
 
 	var (

--- a/cmd/mfa.go
+++ b/cmd/mfa.go
@@ -1,0 +1,131 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"awsm/internal/aws"
+	"awsm/internal/mfa"
+	"awsm/internal/tui"
+
+	"github.com/spf13/cobra"
+)
+
+var mfaCmd = &cobra.Command{
+	Use:   "mfa",
+	Short: "Manage TOTP secrets for automatic MFA token generation",
+	Long: `Store and manage TOTP secrets so awsm can generate MFA tokens automatically,
+without prompting you each time your credentials expire.
+
+Secrets are stored in the OS keychain (macOS Keychain, Windows Credential Manager,
+Linux Secret Service). On headless Linux without a Secret Service, they fall back
+to ~/.awsm/mfa/<profile>.totp with 0600 permissions.`,
+}
+
+var mfaSetCmd = &cobra.Command{
+	Use:   "set [profile]",
+	Short: "Store a TOTP secret for a profile",
+	Long: `Store the TOTP secret (seed) for an AWS profile.
+You can find this secret when setting up a virtual MFA device in the AWS console
+— it's the string shown alongside the QR code.`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		profileName, err := resolveProfileName(stringArg(args, 0))
+		if err != nil {
+			return err
+		}
+
+		secret, err := tui.PromptInput(
+			fmt.Sprintf("TOTP secret for profile %s", tui.FormatBold(profileName)),
+			tui.WithEchoNone(),
+			tui.WithRequired(),
+		)
+		if err != nil {
+			return err
+		}
+
+		if err := mfa.SetTOTPSecret(profileName, secret); err != nil {
+			return fmt.Errorf("failed to store TOTP secret: %w", err)
+		}
+
+		// Optionally update mfa_serial in ~/.aws/config
+		serial, err := tui.PromptInput(
+			"MFA Serial ARN (leave empty to keep current)",
+			tui.WithPlaceholder("arn:aws:iam::123456789012:mfa/username"),
+		)
+		if err != nil {
+			return err
+		}
+		serial = strings.TrimSpace(serial)
+		if serial != "" {
+			if err := aws.UpdateMFASerial(profileName, serial); err != nil {
+				tui.PrintWarning(fmt.Sprintf("TOTP secret stored but failed to update mfa_serial: %v", err))
+			}
+		}
+
+		tui.PrintSuccess(fmt.Sprintf("TOTP secret stored for profile '%s'", profileName))
+		return nil
+	},
+}
+
+var mfaRemoveCmd = &cobra.Command{
+	Use:     "remove [profile]",
+	Aliases: []string{"delete", "rm"},
+	Short:   "Remove the stored TOTP secret for a profile",
+	Args:    cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		profileName, err := resolveProfileName(stringArg(args, 0))
+		if err != nil {
+			return err
+		}
+
+		if err := mfa.DeleteTOTPSecret(profileName); err != nil {
+			return fmt.Errorf("failed to remove TOTP secret: %w", err)
+		}
+
+		tui.PrintSuccess(fmt.Sprintf("TOTP secret removed for profile '%s'", profileName))
+		return nil
+	},
+}
+
+var mfaTestCmd = &cobra.Command{
+	Use:   "test [profile]",
+	Short: "Generate and display the current TOTP code for a profile",
+	Long:  `Generate the current 6-digit TOTP code. Use this to verify that your stored secret is correct by comparing it with your authenticator app.`,
+	Args:  cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		profileName, err := resolveProfileName(stringArg(args, 0))
+		if err != nil {
+			return err
+		}
+
+		code, err := mfa.GenerateTOTP(profileName)
+		if err != nil {
+			return fmt.Errorf("failed to generate TOTP: %w\n\nRun 'awsm mfa set %s' to store a TOTP secret first", err, profileName)
+		}
+
+		fmt.Printf("Current TOTP for '%s': %s\n", profileName, code)
+		return nil
+	},
+}
+
+// stringArg returns args[i] or "" if out of bounds.
+func stringArg(args []string, i int) string {
+	if i < len(args) {
+		return args[i]
+	}
+	return ""
+}
+
+func init() {
+	mfaCmd.AddCommand(mfaSetCmd)
+	mfaCmd.AddCommand(mfaRemoveCmd)
+	mfaCmd.AddCommand(mfaTestCmd)
+
+	// Completion for profile argument
+	mfaSetCmd.RegisterFlagCompletionFunc("profile", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	})
+
+	rootCmd.AddCommand(mfaCmd)
+}

--- a/go.mod
+++ b/go.mod
@@ -31,13 +31,16 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.30.2 // indirect
 	github.com/aws/smithy-go v1.22.2 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
+	github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc // indirect
 	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect
 	github.com/charmbracelet/x/ansi v0.8.0 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13-0.20250311204145-2c3ea96c31dd // indirect
 	github.com/charmbracelet/x/term v0.2.1 // indirect
+	github.com/danieljoos/wincred v1.2.3 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/fsnotify/fsnotify v1.8.0 // indirect
 	github.com/go-viper/mapstructure/v2 v2.2.1 // indirect
+	github.com/godbus/dbus/v5 v5.2.2 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
@@ -47,6 +50,7 @@ require (
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
+	github.com/pquerna/otp v1.5.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/sagikazarmark/locafero v0.7.0 // indirect
 	github.com/sahilm/fuzzy v0.1.1 // indirect
@@ -56,6 +60,7 @@ require (
 	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
+	github.com/zalando/go-keyring v0.2.8 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.9.0 // indirect
 	golang.org/x/exp v0.0.0-20231006140011-7918f672742d // indirect

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,8 @@ github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiE
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/aymanbagabas/go-udiff v0.2.0 h1:TK0fH4MteXUDspT88n8CKzvK0X9O2xu9yQjWpi6yML8=
 github.com/aymanbagabas/go-udiff v0.2.0/go.mod h1:RE4Ex0qsGkTAJoQdQQCA0uG+nAzJO/pI/QwceO5fgrA=
+github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc h1:biVzkmvwrH8WK8raXaxBx6fRVTlJILwEwQGL1I/ByEI=
+github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/charmbracelet/bubbles v0.21.0 h1:9TdC97SdRVg/1aaXNVWfFH3nnLAwOXr8Fn6u6mfQdFs=
 github.com/charmbracelet/bubbles v0.21.0/go.mod h1:HF+v6QUR4HkEpz62dx7ym2xc71/KBHg+zKwJtMw+qtg=
 github.com/charmbracelet/bubbletea v1.3.5 h1:JAMNLTbqMOhSwoELIr0qyP4VidFq72/6E9j7HHmRKQc=
@@ -49,6 +51,8 @@ github.com/charmbracelet/x/exp/golden v0.0.0-20241011142426-46044092ad91/go.mod 
 github.com/charmbracelet/x/term v0.2.1 h1:AQeHeLZ1OqSXhrAWpYUtZyX1T3zVxfpZuEQMIQaGIAQ=
 github.com/charmbracelet/x/term v0.2.1/go.mod h1:oQ4enTYFV7QN4m0i9mzHrViD7TQKvNEEkHUMCmsxdUg=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/danieljoos/wincred v1.2.3 h1:v7dZC2x32Ut3nEfRH+vhoZGvN72+dQ/snVXo/vMFLdQ=
+github.com/danieljoos/wincred v1.2.3/go.mod h1:6qqX0WNrS4RzPZ1tnroDzq9kY3fu1KwE7MRLQK4X0bs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -62,6 +66,8 @@ github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/
 github.com/fsnotify/fsnotify v1.8.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/go-viper/mapstructure/v2 v2.2.1 h1:ZAaOCxANMuZx5RCeg0mBdEZk7DZasvvZIxtHqx8aGss=
 github.com/go-viper/mapstructure/v2 v2.2.1/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
+github.com/godbus/dbus/v5 v5.2.2 h1:TUR3TgtSVDmjiXOgAAyaZbYmIeP3DPkld3jgKGV8mXQ=
+github.com/godbus/dbus/v5 v5.2.2/go.mod h1:3AAv2+hPq5rdnr5txxxRwiGjPXamgoIHgz9FPBfOp3c=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
@@ -95,6 +101,8 @@ github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmd
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/pquerna/otp v1.5.0 h1:NMMR+WrmaqXU4EzdGJEE1aUUI0AMRzsp96fFFWNPwxs=
+github.com/pquerna/otp v1.5.0/go.mod h1:dkJfzwRKNiegxyNb54X/3fLwhCynbMspSyWKnvi1AEg=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
@@ -125,6 +133,8 @@ github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
+github.com/zalando/go-keyring v0.2.8 h1:6sD/Ucpl7jNq10rM2pgqTs0sZ9V3qMrqfIIy5YPccHs=
+github.com/zalando/go-keyring v0.2.8/go.mod h1:tsMo+VpRq5NGyKfxoBVjCuMrG47yj8cmakZDO5QGii0=
 go.uber.org/atomic v1.9.0 h1:ECmE8Bn/WFTYwEW/bpKD3M8VtR/zQVbavAoalC1PYyE=
 go.uber.org/atomic v1.9.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/multierr v1.9.0 h1:7fIwc/ZtS0q++VgcfqFDxSBZVv/Xo49/SYnDFupUwlI=

--- a/internal/aws/config.go
+++ b/internal/aws/config.go
@@ -542,6 +542,29 @@ func UpdateIAMRoleProfile(profileName, roleArn, sourceProfile, mfaSerial, region
 	return cfg.SaveTo(configPath)
 }
 
+// UpdateMFASerial updates only the mfa_serial key for an existing profile.
+func UpdateMFASerial(profileName, mfaSerial string) error {
+	configPath, err := GetAWSConfigPath()
+	if err != nil {
+		return err
+	}
+	cfg, err := ini.Load(configPath)
+	if err != nil {
+		return fmt.Errorf("failed to load config file: %w", err)
+	}
+	section, err := getProfileSection(cfg, profileName)
+	if err != nil {
+		return err
+	}
+	if mfaSerial != "" {
+		section.Key("mfa_serial").SetValue(mfaSerial)
+	} else {
+		section.DeleteKey("mfa_serial")
+	}
+	InvalidateProfileCache()
+	return cfg.SaveTo(configPath)
+}
+
 // DeleteProfile removes a profile from both config and credentials files
 func DeleteProfile(profileName string) error {
 	// Delete from config file

--- a/internal/mfa/totp.go
+++ b/internal/mfa/totp.go
@@ -1,0 +1,120 @@
+package mfa
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/pquerna/otp/totp"
+	"github.com/zalando/go-keyring"
+)
+
+const keyringSvc = "awsm"
+
+// SetTOTPSecret stores the TOTP secret for a profile.
+// Tries OS keyring first; falls back to a plain-text file (~/.awsm/mfa/<profile>.totp)
+// with 0600 permissions when keyring is unavailable (e.g. headless Linux).
+func SetTOTPSecret(profileName, secret string) error {
+	secret = strings.ToUpper(strings.ReplaceAll(secret, " ", ""))
+	secret = strings.TrimSpace(secret)
+	if secret == "" {
+		return fmt.Errorf("TOTP secret cannot be empty")
+	}
+
+	// Validate it's a real TOTP secret before storing
+	if _, err := totp.GenerateCode(secret, time.Now()); err != nil {
+		return fmt.Errorf("invalid TOTP secret: %w", err)
+	}
+
+	if err := keyring.Set(keyringSvc, profileName, secret); err != nil {
+		// Keyring unavailable — fall back to file
+		if fileErr := writeSecretFile(profileName, secret); fileErr != nil {
+			return fmt.Errorf("keyring unavailable (%v) and file fallback failed: %w", err, fileErr)
+		}
+		fmt.Fprintf(os.Stderr, "Warning: OS keyring unavailable. TOTP secret stored in ~/.awsm/mfa/%s.totp (mode 0600).\n", profileName)
+		return nil
+	}
+	return nil
+}
+
+// GetTOTPSecret retrieves the TOTP secret for a profile.
+func GetTOTPSecret(profileName string) (string, error) {
+	secret, err := keyring.Get(keyringSvc, profileName)
+	if err == nil {
+		return secret, nil
+	}
+
+	// Try file fallback
+	secret, fileErr := readSecretFile(profileName)
+	if fileErr != nil {
+		return "", fmt.Errorf("no TOTP secret found for profile %q", profileName)
+	}
+	return secret, nil
+}
+
+// DeleteTOTPSecret removes the stored TOTP secret for a profile.
+func DeleteTOTPSecret(profileName string) error {
+	keyringErr := keyring.Delete(keyringSvc, profileName)
+	fileErr := deleteSecretFile(profileName)
+
+	if keyringErr != nil && fileErr != nil {
+		return fmt.Errorf("no TOTP secret found for profile %q", profileName)
+	}
+	return nil
+}
+
+// GenerateTOTP generates the current 6-digit TOTP code for a profile.
+// Returns an error if no secret is configured for the profile.
+func GenerateTOTP(profileName string) (string, error) {
+	secret, err := GetTOTPSecret(profileName)
+	if err != nil {
+		return "", err
+	}
+	code, err := totp.GenerateCode(secret, time.Now())
+	if err != nil {
+		return "", fmt.Errorf("failed to generate TOTP for profile %q: %w", profileName, err)
+	}
+	return code, nil
+}
+
+// secretFilePath returns the path for the file-based fallback secret.
+func secretFilePath(profileName string) (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".awsm", "mfa", profileName+".totp"), nil
+}
+
+func writeSecretFile(profileName, secret string) error {
+	path, err := secretFilePath(profileName)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return err
+	}
+	return os.WriteFile(path, []byte(secret), 0600)
+}
+
+func readSecretFile(profileName string) (string, error) {
+	path, err := secretFilePath(profileName)
+	if err != nil {
+		return "", err
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(data)), nil
+}
+
+func deleteSecretFile(profileName string) error {
+	path, err := secretFilePath(profileName)
+	if err != nil {
+		return err
+	}
+	return os.Remove(path)
+}

--- a/internal/mfa/totp_test.go
+++ b/internal/mfa/totp_test.go
@@ -1,0 +1,213 @@
+package mfa
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/pquerna/otp/totp"
+	"github.com/zalando/go-keyring"
+)
+
+// validSecret is a known-good base32 TOTP seed usable in tests.
+const validSecret = "JBSWY3DPEHPK3PXP"
+
+func init() {
+	// Redirect all keyring operations to an in-memory mock so tests never
+	// touch the real OS keychain.
+	keyring.MockInit()
+}
+
+// setTempHome redirects UserHomeDir by overriding HOME so file-fallback paths
+// land in a temporary directory. Returns a cleanup func.
+func setTempHome(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	// USERPROFILE is used on Windows
+	t.Setenv("USERPROFILE", dir)
+	return dir
+}
+
+// TestSetTOTPSecret_StoresAndRetrieves verifies round-trip via keyring mock.
+func TestSetTOTPSecret_StoresAndRetrieves(t *testing.T) {
+	setTempHome(t)
+	const profile = "test-profile"
+
+	if err := SetTOTPSecret(profile, validSecret); err != nil {
+		t.Fatalf("SetTOTPSecret: %v", err)
+	}
+
+	got, err := GetTOTPSecret(profile)
+	if err != nil {
+		t.Fatalf("GetTOTPSecret: %v", err)
+	}
+	if got != validSecret {
+		t.Errorf("got %q, want %q", got, validSecret)
+	}
+}
+
+// TestSetTOTPSecret_NormalizesSpacesAndCase ensures secrets with spaces or
+// lowercase are stored as clean uppercase base32.
+func TestSetTOTPSecret_NormalizesSpacesAndCase(t *testing.T) {
+	setTempHome(t)
+	const profile = "norm-profile"
+	withSpaces := "jbsw y3dp ehpk 3pxp" // same secret, lowercase + spaces
+
+	if err := SetTOTPSecret(profile, withSpaces); err != nil {
+		t.Fatalf("SetTOTPSecret: %v", err)
+	}
+
+	got, err := GetTOTPSecret(profile)
+	if err != nil {
+		t.Fatalf("GetTOTPSecret: %v", err)
+	}
+	if got != validSecret {
+		t.Errorf("got %q, want %q", got, validSecret)
+	}
+}
+
+// TestSetTOTPSecret_RejectsEmpty ensures empty or whitespace-only input fails.
+func TestSetTOTPSecret_RejectsEmpty(t *testing.T) {
+	setTempHome(t)
+	for _, input := range []string{"", "   "} {
+		if err := SetTOTPSecret("p", input); err == nil {
+			t.Errorf("expected error for empty secret %q", input)
+		}
+	}
+}
+
+// TestSetTOTPSecret_RejectsInvalidBase32 ensures garbage secrets are rejected.
+func TestSetTOTPSecret_RejectsInvalidBase32(t *testing.T) {
+	setTempHome(t)
+	if err := SetTOTPSecret("p", "NOT!VALID@BASE32#"); err == nil {
+		t.Error("expected error for invalid base32 secret")
+	}
+}
+
+// TestDeleteTOTPSecret_RemovesEntry verifies the secret is gone after deletion.
+func TestDeleteTOTPSecret_RemovesEntry(t *testing.T) {
+	setTempHome(t)
+	const profile = "del-profile"
+
+	if err := SetTOTPSecret(profile, validSecret); err != nil {
+		t.Fatalf("SetTOTPSecret: %v", err)
+	}
+	if err := DeleteTOTPSecret(profile); err != nil {
+		t.Fatalf("DeleteTOTPSecret: %v", err)
+	}
+	if _, err := GetTOTPSecret(profile); err == nil {
+		t.Error("expected error after deletion, got nil")
+	}
+}
+
+// TestDeleteTOTPSecret_NonExistent returns an error when nothing is stored.
+func TestDeleteTOTPSecret_NonExistent(t *testing.T) {
+	setTempHome(t)
+	if err := DeleteTOTPSecret("ghost-profile"); err == nil {
+		t.Error("expected error deleting non-existent secret")
+	}
+}
+
+// TestGetTOTPSecret_NotFound returns an error for unknown profile.
+func TestGetTOTPSecret_NotFound(t *testing.T) {
+	setTempHome(t)
+	if _, err := GetTOTPSecret("no-such-profile"); err == nil {
+		t.Error("expected error, got nil")
+	}
+}
+
+// TestGenerateTOTP_ProducesValidCode verifies the generated code is 6 digits
+// and matches what pquerna/otp would produce for the same instant.
+func TestGenerateTOTP_ProducesValidCode(t *testing.T) {
+	setTempHome(t)
+	const profile = "gen-profile"
+
+	if err := SetTOTPSecret(profile, validSecret); err != nil {
+		t.Fatalf("SetTOTPSecret: %v", err)
+	}
+
+	now := time.Now()
+	code, err := GenerateTOTP(profile)
+	if err != nil {
+		t.Fatalf("GenerateTOTP: %v", err)
+	}
+
+	if len(code) != 6 {
+		t.Errorf("expected 6-digit code, got %q (len %d)", code, len(code))
+	}
+	for _, ch := range code {
+		if ch < '0' || ch > '9' {
+			t.Errorf("non-digit in TOTP code: %q", code)
+		}
+	}
+
+	expected, _ := totp.GenerateCode(validSecret, now)
+	if code != expected {
+		t.Errorf("code mismatch: got %q, want %q", code, expected)
+	}
+}
+
+// TestGenerateTOTP_NoSecret returns an error when no secret is stored.
+func TestGenerateTOTP_NoSecret(t *testing.T) {
+	setTempHome(t)
+	if _, err := GenerateTOTP("no-secret-profile"); err == nil {
+		t.Error("expected error, got nil")
+	}
+}
+
+// TestFileFallback_RoundTrip exercises the file-based storage path directly.
+func TestFileFallback_RoundTrip(t *testing.T) {
+	dir := setTempHome(t)
+
+	const profile = "file-profile"
+	if err := writeSecretFile(profile, validSecret); err != nil {
+		t.Fatalf("writeSecretFile: %v", err)
+	}
+
+	got, err := readSecretFile(profile)
+	if err != nil {
+		t.Fatalf("readSecretFile: %v", err)
+	}
+	if got != validSecret {
+		t.Errorf("got %q, want %q", got, validSecret)
+	}
+
+	// Verify file permissions and location
+	path := filepath.Join(dir, ".awsm", "mfa", profile+".totp")
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0600 {
+		t.Errorf("file permissions: got %04o, want 0600", perm)
+	}
+
+	if err := deleteSecretFile(profile); err != nil {
+		t.Fatalf("deleteSecretFile: %v", err)
+	}
+	if _, err := readSecretFile(profile); err == nil {
+		t.Error("expected error after delete")
+	}
+}
+
+// TestFileFallback_StripsWhitespace ensures trailing newlines in file are handled.
+func TestFileFallback_StripsWhitespace(t *testing.T) {
+	setTempHome(t)
+	const profile = "ws-profile"
+
+	withNewline := validSecret + "\n"
+	if err := writeSecretFile(profile, withNewline); err != nil {
+		t.Fatalf("writeSecretFile: %v", err)
+	}
+
+	got, err := readSecretFile(profile)
+	if err != nil {
+		t.Fatalf("readSecretFile: %v", err)
+	}
+	if strings.Contains(got, "\n") {
+		t.Errorf("readSecretFile did not strip newline: %q", got)
+	}
+}


### PR DESCRIPTION
Store TOTP secrets in OS keychain (macOS Keychain, Windows Credential Manager, Linux Secret Service) and auto-generate MFA tokens so users are never prompted for a 6-digit code when credentials expire.

Falls back to plaintext file (~/.awsm/mfa/<profile>.totp, mode 0600) on headless Linux without a Secret Service, with a warning.

New commands:
  awsm mfa set [profile]    – store TOTP secret + optionally update mfa_serial
  awsm mfa remove [profile] – remove stored secret
  awsm mfa test [profile]   – print current code for verification